### PR TITLE
Do not crash homebridge if multicast socket already bound

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-yeelight-wifi",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "description": "Homebridge plugin for Yeelight white and colored bulbs.",
   "license": "MIT",
   "keywords": [
@@ -17,8 +17,7 @@
   "bugs": {
     "url": "http://github.com/vieira/homebridge-yeelight-wifi/issues"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "^4.10.0",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/platform.js
+++ b/platform.js
@@ -20,6 +20,12 @@ class YeePlatform {
     this.sock = dgram.createSocket('udp4');
     this.devices = {};
 
+    this.sock.on('error', (err) => {
+      this.sock.close();
+      this.log(err.message);
+      this.devices = {};
+    });
+
     this.sock.bind(this.port, () => {
       this.sock.setBroadcast(true);
       this.sock.setMulticastTTL(128);


### PR DESCRIPTION
For users running multiple instances of homebridge it is not convenient that we crash and exit homebridge if we fail to bind the multicast udp socket.

This changes logs the error but leaves homebridge running.

Tentative fix for the issue reported in #10.