### PR TITLE
Dont register platform if not defined in configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const YeePlatform = require('./platform');
 
 module.exports = (homebridge) => {
@@ -6,6 +7,18 @@ module.exports = (homebridge) => {
   global.Characteristic = homebridge.hap.Characteristic;
   global.UUIDGen = homebridge.hap.uuid;
   global.EOL = '\r\n';
+
+  const configPath = homebridge.user.configPath();
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath));
+    const platforms = config.platforms || [];
+    if (!platforms.find(({ platform }) => platform === 'yeelight')) return;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      // eslint-disable-next-line no-console
+      console.error(err.message);
+    }
+  }
 
   homebridge.registerPlatform(
     'homebridge-yeelight',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-yeelight-wifi",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "description": "Homebridge plugin for Yeelight white and colored bulbs.",
   "license": "MIT",
   "keywords": [
@@ -17,8 +17,7 @@
   "bugs": {
     "url": "http://github.com/vieira/homebridge-yeelight-wifi/issues"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "^4.10.0",
     "eslint-config-airbnb-base": "^12.1.0",


### PR DESCRIPTION
For users running multiple instances of homebridge it is convenient that we offer a way to signal the plugin that it should not load, otherwise when multiple instances are running in the same machine, there is no way to selectively disable our plugin.

Expected behaviour is as follows:
1. If there is no configuration file, the plugin will register the platform. This is useful for users with simple needs to have a working environment without any need for manual configuration.
2. If there is a configuration file:
 2.1. If the yeelight platform is configured, register the plarform and go on as usual.
 2.2 If the platform is not defined in the file, do not register the platform.

Example configuration that will cause the plugin to register the platform:
```json
{
    "bridge": {
        "name": "Raspberry Pi",
        "(...)"
    },
    "accessories": [{
        "accessory": "SenseHat",
        "(...)"
    }],
    "platforms": [{
        "platform": "yeelight",
        "name": "Yeelight"
    }]
}
```

Example configurations that will cause the plugin to **NOT** register the platform:
```json
{
    "bridge": {
        "name": "Raspberry Pi",
        "(...)"
    },
    "accessories": [{
        "accessory": "SenseHat",
        "(...)"
    }],
    "platforms": [{
        "platform": "foobar",
        "name": "Foobar"
    }]
}
```

```json
{
    "bridge": {
        "name": "Raspberry Pi",
        "(...)"
    },
    "accessories": [{
        "accessory": "SenseHat",
        "(...)"
    }]
}
```

Should fix the issue reported in #10.
