### PR TITLE
Color temperature range adjustment based on model

### DIFF
--- a/bulbs/temperature.js
+++ b/bulbs/temperature.js
@@ -53,7 +53,7 @@ const Temperature = ({ ct }) => Device => class extends Device {
         }
       }).setProps({
         minValue: 154, // ~6500K
-        maxValue: 588, // ~1700K
+        maxValue: this.model.startsWith('bslamp') ? 588 : 370, // ~1700K or ~2700K
       }).updateValue(this.temperature);
   }
 };


### PR DESCRIPTION
Looks like only bed side lamp supports 1700K min color temperature while others (ceiling lights for sure) support 2700K.