### PR TITLE
Fix: Do not add device ID to the "Moonlight Mode" switches

### DIFF
--- a/bulbs/moonlight.js
+++ b/bulbs/moonlight.js
@@ -1,5 +1,3 @@
-const { name } = require('../utils');
-
 /** Support for "moonlight" mode for ceiling lamps
  * active_mode:
  *  0 - Daylight mode |
@@ -42,12 +40,10 @@ const MoonlightMode = ({ bright: b, active_mode: activeMode = 0 }) => Device => 
   }
 
   configureServices() {
-    const deviceId = this.did.slice(-6);
-    const deviceName = name(deviceId, this.config);
     super.configureServices();
 
     this.moonlightModeService = this.accessory.getService(global.Service.Switch)
-      || this.accessory.addService(new global.Service.Switch(`${deviceName} Moonlight Mode`));
+      || this.accessory.addService(new global.Service.Switch('Moonlight Mode'));
 
     this.moonlightModeService.getCharacteristic(global.Characteristic.On)
       .on('set', async (value, callback) => {


### PR DESCRIPTION
This results in better names that work without renaming out of the box. Since in the latest Home.app devices are grouped anyway, it should not be a problem for most users.