### PR TITLE
Fix: Resolve warnings invalid response in SET handler

### DIFF
--- a/bulbs/brightness.js
+++ b/bulbs/brightness.js
@@ -11,9 +11,9 @@ const Brightness = Device =>
         .on('set', async (value, callback) => {
           try {
             await this.setBrightness(value);
-            callback(null, value);
+            callback(null);
           } catch (err) {
-            callback(err, this.bright);
+            callback(err);
           }
         })
         .updateValue(this.bright);

--- a/bulbs/bulb.js
+++ b/bulbs/bulb.js
@@ -37,9 +37,9 @@ class YeeBulb {
       .on('set', async (value, callback) => {
         try {
           await this.setPower(value);
-          callback(null, value);
+          callback(null);
         } catch (err) {
-          callback(err, this.power);
+          callback(err);
         }
       })
       .on('get', async callback => {

--- a/bulbs/color.js
+++ b/bulbs/color.js
@@ -19,9 +19,9 @@ const Color = Device => {
         .on('set', async (value, callback) => {
           try {
             await this.setColor(value, null);
-            callback(null, this.hue);
+            callback(null);
           } catch (err) {
-            callback(err, this.hue);
+            callback(err);
           }
         })
         .updateValue(this.hue);
@@ -33,9 +33,9 @@ const Color = Device => {
         .on('set', async (value, callback) => {
           try {
             await this.setColor(null, value);
-            callback(null, this.sat);
+            callback(null);
           } catch (err) {
-            callback(err, this.sat);
+            callback(err);
           }
         })
         .updateValue(this.sat);

--- a/bulbs/moonlight.js
+++ b/bulbs/moonlight.js
@@ -20,9 +20,9 @@ const MoonlightMode = Device =>
         .on('set', async (value, callback) => {
           try {
             await this.setMoonlightMode(value);
-            callback(null, this.activeMode);
+            callback(null);
           } catch (err) {
-            callback(err, this.activeMode);
+            callback(err);
           }
         })
         .on('get', async callback => {

--- a/bulbs/temperature.js
+++ b/bulbs/temperature.js
@@ -17,15 +17,15 @@ const Temperature = Device =>
              */
             if (this.activeMode === 0) {
               await this.setTemperature(value);
-              callback(null, value);
+              callback(null);
             } else {
               platform.log.debug(
                 `Device ${this.did} activeMode is ${this.activeMode}. Skipping setting temperature in moonlight mode.`
               );
-              callback(null, this.temperature);
+              callback(null);
             }
           } catch (err) {
-            callback(err, this.temperature);
+            callback(err);
           }
         })
         .setProps({


### PR DESCRIPTION
This should fix #92.

The callback for the characteristic set handler is not expected to be called with a value, only with `null` or `err` as documented in https://github.com/homebridge/homebridge/wiki/Characteristic-Warnings.