### PR TITLE
Release 3.0.0 - Backlight/Ambilight Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ typings/
 # homebridge
 /homebridge/accessories
 /homebridge/persist
+
+debug

--- a/bulbs/backlight/brightness.js
+++ b/bulbs/backlight/brightness.js
@@ -1,0 +1,56 @@
+const BacklightBrightness = (Device) =>
+  class extends Device {
+    constructor(props, platform) {
+      super(props, platform);
+      this.backlightBright = props['bg_bright'];
+
+      const { Brightness } = global.Characteristic;
+
+      (
+        this.backlightService.getCharacteristic(Brightness) ||
+        this.backlightService.addCharacteristic(Brightness)
+      )
+        .on('set', async (value, callback) => {
+          try {
+            await this.setBacklightBrightness(value);
+            callback(null);
+          } catch (err) {
+            callback(err);
+          }
+        })
+        .updateValue(this.backlightBright);
+    }
+
+    get backlightBright() {
+      return this._backlightBright;
+    }
+
+    set backlightBright(brightness) {
+      this._backlightBright = Number(brightness);
+    }
+
+    async setBacklightBrightness(brightness) {
+      const { brightness: transition = 400 } = this.config.transitions || {};
+      await this.setBacklightPower(true);
+      const req = {
+        method: 'bg_set_bright',
+        params: [Math.max(brightness, 1), 'smooth', transition],
+      };
+      return this.sendCmd(req).then(() => {
+        this._backlightBright = brightness;
+      });
+    }
+
+    updateStateFromProp(prop, value) {
+      if (prop === 'bg_bright') {
+        this.backlightBright = value;
+        this.backlightService
+          .getCharacteristic(global.Characteristic.Brightness)
+          .updateValue(this.backlightBright);
+        return;
+      }
+      super.updateStateFromProp(prop, value);
+    }
+  };
+
+module.exports = BacklightBrightness;

--- a/bulbs/backlight/bulb.js
+++ b/bulbs/backlight/bulb.js
@@ -1,0 +1,67 @@
+const Backlight = (Device) =>
+  class extends Device {
+    constructor(props, platform) {
+      super(props, platform);
+
+      const { Lightbulb } = global.Service;
+
+      this.backlightService =
+        this.accessory.getService('backlight') ||
+        this.accessory.addService(new Lightbulb(this.name, 'backlight'));
+
+      this.backlightService
+        .getCharacteristic(global.Characteristic.On)
+        .on('set', async (value, callback) => {
+          try {
+            await this.setBacklightPower(value);
+            callback(null);
+          } catch (err) {
+            callback(err);
+          }
+        })
+        .on('get', async (callback) => {
+          try {
+            const [value] = await this.getProperty(['bg_power']);
+            this.backlightPower = value;
+            callback(null, this.backlightPower);
+          } catch (err) {
+            callback(err, this.backlightPower);
+          }
+        })
+        .updateValue(this.backlightPower);
+    }
+
+    get backlightPower() {
+      return !!this._backlightPower;
+    }
+
+    set backlightPower(state) {
+      this._backlightPower = state === 'on' ? true : false;
+    }
+
+    updateStateFromProp(prop, value) {
+      if (prop === 'bg_power') {
+        this.backlightPower = value;
+        this.backlightService
+          .getCharacteristic(global.Characteristic.On)
+          .updateValue(this.backlightPower);
+      }
+      super.updateStateFromProp(prop, value);
+    }
+
+    async setBacklightPower(backlightPower) {
+      if (this.backlightPower === backlightPower) {
+        return backlightPower;
+      }
+      const { power: transition = 400 } = this.config.transitions || {};
+      const state = backlightPower ? 'on' : 'off';
+      const req = {
+        method: 'bg_set_power',
+        params: [state, 'smooth', transition],
+      };
+      await this.sendCmd(req);
+      this.backlightPower = state;
+    }
+  };
+
+module.exports = Backlight;

--- a/bulbs/backlight/color.js
+++ b/bulbs/backlight/color.js
@@ -1,0 +1,102 @@
+const { isInteger } = Number;
+
+const BacklightColor = (Device) => {
+  let hue;
+  let sat;
+
+  return class extends Device {
+    constructor(props, platform) {
+      super(props, platform);
+      this.backlightHue = props['bg_hue'];
+      this.backlightSat = props['bg_sat'];
+
+      const { Hue, Saturation } = global.Characteristic;
+
+      (
+        this.backlightService.getCharacteristic(Hue) ||
+        this.backlightService.addCharacteristic(Hue)
+      )
+        .on('set', async (value, callback) => {
+          try {
+            await this.setBacklightColor(value, null);
+            callback(null);
+          } catch (err) {
+            callback(err);
+          }
+        })
+        .updateValue(this.backlightHue);
+
+      (
+        this.backlightService.getCharacteristic(Saturation) ||
+        this.backlightService.addCharacteristic(Saturation)
+      )
+        .on('set', async (value, callback) => {
+          try {
+            await this.setBacklightColor(null, value);
+            callback(null);
+          } catch (err) {
+            callback(err);
+          }
+        })
+        .updateValue(this.backlightSat);
+    }
+
+    get backlightHue() {
+      return this._backlightHue;
+    }
+
+    set backlightHue(value) {
+      this._backlightHue = Number(value);
+    }
+
+    get backlightSat() {
+      return this._backlightSat;
+    }
+
+    set backlightSat(value) {
+      this._backlightSat = Number(value);
+    }
+
+    updateStateFromProp(prop, value) {
+      if (prop === 'bg_hue') {
+        this.backlightHue = value;
+        this.backlightService
+          .getCharacteristic(global.Characteristic.Hue)
+          .updateValue(this.backlightHue);
+        return;
+      }
+      if (prop === 'bg_sat') {
+        this.backlightSat = value;
+        this.backlightService
+          .getCharacteristic(global.Characteristic.Saturation)
+          .updateValue(this.backlightSat);
+        return;
+      }
+      if (prop === 'bg_rgb') {
+        return;
+      }
+      super.updateStateFromProp(prop, value);
+    }
+
+    async setBacklightColor(hv, sv) {
+      hue = isInteger(hue) ? hue : hv;
+      sat = isInteger(sat) ? sat : sv;
+      if (!isInteger(hue) || !isInteger(sat)) return;
+
+      const { color: transition = 400 } = this.config.transitions || {};
+      await this.setBacklightPower(true);
+      const req = {
+        method: 'bg_set_hsv',
+        params: [hue, sat, 'smooth', transition],
+      };
+      return this.sendCmd(req).then(() => {
+        this._backlightHue = hue;
+        this._backlightSat = sat;
+        hue = null;
+        sat = null;
+      });
+    }
+  };
+};
+
+module.exports = BacklightColor;

--- a/bulbs/brightness.js
+++ b/bulbs/brightness.js
@@ -42,10 +42,9 @@ const Brightness = Device =>
     updateStateFromProp(prop, value) {
       // There are different props being used for brightness
       // depending on the active_mode in Ceiling lamps
-      if (
-        (this.activeMode === 0 && prop === 'bright') ||
-        (this.activeMode === 1 && prop === 'nl_br')
-      ) {
+      if (prop === 'bright' && this.activeMode === 1) return;
+      if (prop === 'nl_br' && this.activeMode !== 1) return;
+      if (['bright', 'nl_br'].includes(prop)) {
         this.bright = value;
         this.service
           .getCharacteristic(global.Characteristic.Brightness)

--- a/bulbs/bulb.js
+++ b/bulbs/bulb.js
@@ -27,6 +27,8 @@ class YeeBulb {
       this.accessory.getService(global.Service.Lightbulb) ||
       this.accessory.addService(new global.Service.Lightbulb(this.name));
 
+    this.service.setPrimaryService();
+
     this.accessory.on('identify', async (_, callback) => {
       await this.identify();
       callback();
@@ -44,7 +46,7 @@ class YeeBulb {
       })
       .on('get', async (callback) => {
         try {
-          const [value] = await this.getProperty(['power', 'active_mode']);
+          const [value] = await this.getProperty(['power']);
           this.power = value;
           callback(null, this.power);
         } catch (err) {

--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,11 @@
+{
+  "bslamp": {
+    "colorTemperature": [154, 588]
+  },
+  "color5": {
+    "colorTemperature": [154, 588]
+  },
+  "default": {
+    "colorTemperature": [154, 370]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "parserOptions": {
-      "ecmaVersion": 2019
+      "ecmaVersion": 2020
     },
     "env": {
       "node": true,

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "prettier": "^3.0.2"
   },
   "engines": {
-    "node": ">=12.22.0",
-    "homebridge": ">=0.4.0"
+    "node": ">=16.16.0",
+    "homebridge": ">=1.3.0"
   },
   "scripts": {
     "prepare": "husky install",

--- a/platform.js
+++ b/platform.js
@@ -6,6 +6,7 @@ const MoonlightMode = require('./bulbs/moonlight');
 const Color = require('./bulbs/color');
 const Temperature = require('./bulbs/temperature');
 const Backlight = require('./bulbs/backlight/bulb');
+const BacklightBrightness = require('./bulbs/backlight/brightness');
 const { getDeviceId, getName, blacklist, sleep, pipe } = require('./utils');
 
 class YeePlatform {
@@ -150,6 +151,11 @@ class YeePlatform {
     if (features.includes('bg_set_power')) {
       this.log(`Device ${name} supports backlight`);
       mixins.push(Backlight);
+    }
+
+    if (features.includes('bg_set_bright')) {
+      this.log(`Device ${name} supports backlight brightness`);
+      mixins.push(BacklightBrightness);
     }
 
     const Bulb = class extends pipe(...mixins)(YeeBulb) {};

--- a/platform.js
+++ b/platform.js
@@ -7,6 +7,7 @@ const Color = require('./bulbs/color');
 const Temperature = require('./bulbs/temperature');
 const Backlight = require('./bulbs/backlight/bulb');
 const BacklightBrightness = require('./bulbs/backlight/brightness');
+const BacklightColor = require('./bulbs/backlight/color');
 const { getDeviceId, getName, blacklist, sleep, pipe } = require('./utils');
 
 class YeePlatform {
@@ -156,6 +157,11 @@ class YeePlatform {
     if (features.includes('bg_set_bright')) {
       this.log(`Device ${name} supports backlight brightness`);
       mixins.push(BacklightBrightness);
+    }
+
+    if (features.includes('bg_set_hsv')) {
+      this.log(`Device ${name} supports backlight color`);
+      mixins.push(BacklightColor);
     }
 
     const Bulb = class extends pipe(...mixins)(YeeBulb) {};

--- a/platform.js
+++ b/platform.js
@@ -5,6 +5,7 @@ const Brightness = require('./bulbs/brightness');
 const MoonlightMode = require('./bulbs/moonlight');
 const Color = require('./bulbs/color');
 const Temperature = require('./bulbs/temperature');
+const Backlight = require('./bulbs/backlight/bulb');
 const { getDeviceId, getName, blacklist, sleep, pipe } = require('./utils');
 
 class YeePlatform {
@@ -144,6 +145,11 @@ class YeePlatform {
     if (features.includes('set_ct_abx')) {
       this.log(`Device ${name} supports color temperature`);
       mixins.push(Temperature);
+    }
+
+    if (features.includes('bg_set_power')) {
+      this.log(`Device ${name} supports backlight`);
+      mixins.push(Backlight);
     }
 
     const Bulb = class extends pipe(...mixins)(YeeBulb) {};

--- a/platform.js
+++ b/platform.js
@@ -1,20 +1,11 @@
 const dgram = require('dgram');
+const devices = require('./devices.json');
 const YeeBulb = require('./bulbs/bulb');
 const Brightness = require('./bulbs/brightness');
 const MoonlightMode = require('./bulbs/moonlight');
 const Color = require('./bulbs/color');
 const Temperature = require('./bulbs/temperature');
 const { getDeviceId, getName, blacklist, sleep, pipe } = require('./utils');
-
-const MODELS = {
-  MONO: 'mono', // Color Temperature Bulb
-  COLOR: 'color', // RGB Bulb
-  STRIPE: 'stripe', // LED Stripe
-  CEILING: 'ceiling', // Ceiling lights
-  CEILC: 'ceilc', // Ceiling light Yeelight 450c
-  BSLAMP: 'bslamp', // Bed side lamp
-  LAMP: 'lamp', // Star Lamp etc.
-};
 
 class YeePlatform {
   constructor(log, config, api) {
@@ -133,10 +124,10 @@ class YeePlatform {
     if (accessory && accessory.initialized) return;
 
     const mixins = [];
-    const family = Object.values(MODELS).find((fam) => model.startsWith(fam));
+    const limits = devices[model] || devices['default'];
 
     // Lamps that support moonlight mode
-    if ([MODELS.CEILING, MODELS.LAMP, MODELS.CEILC].includes(family)) {
+    if (features.includes('active_mode')) {
       this.log(`Device ${name} supports moonlight mode`);
       mixins.push(MoonlightMode);
     }
@@ -157,7 +148,7 @@ class YeePlatform {
     }
 
     const Bulb = class extends pipe(...mixins)(YeeBulb) {};
-    return new Bulb({ id, name, model, endpoint, accessory, ...props }, this);
+    return new Bulb({ id, model, endpoint, accessory, limits, ...props }, this);
   }
 }
 

--- a/platform.js
+++ b/platform.js
@@ -28,8 +28,7 @@ class YeePlatform {
       this.sock.setBroadcast(true);
       this.sock.setMulticastTTL(128);
       this.sock.addMembership(this.addr);
-      const multicastInterface =
-        config && config.multicast && config.multicast.interface;
+      const multicastInterface = config?.multicast?.interface;
       if (multicastInterface) {
         this.sock.setMulticastInterface(multicastInterface);
       }
@@ -121,7 +120,7 @@ class YeePlatform {
       ]);
     }
 
-    if (accessory && accessory.initialized) return;
+    if (accessory?.initialized) return;
 
     const mixins = [];
     const limits = devices[model] || devices['default'];


### PR DESCRIPTION
This PR introduces initial support for controlling the power, brightness and color of the **backlight (also known as ambilight)** of YeeLight devices that have support for it. :tada:

It also changes the way moonlight mode is detected to not depend on model names, instead looking for the presence of the property `active_mode`, which should only exist in devices supporting moonlight, according to the spec. This also allows the feature to be blacklisted in `config.json` in case you don't want it (see README on how to blacklist features).

Please note that 3.x requires node >= 16.16 and homebridge >= 1.3.0.

Related issues: #102, #81, #78, #65, #51, #40, #108

**Not seeing the new features?**
Your device might be cached. Edit the `config.json` and add the following block (**replace** `5c4bc1` with the id of your device) and restart homebridge.

```
"platforms": [
  {
    "platform": "yeelight",
    "name": "Yeelight",
    "defaultValue": {
      "5c4bc1": {
        "blacklist": true
      }
    }
  }
]
```

Your device will disappear from the Home app.

After that you can **revert back** your `config.json` (removing `"blacklist": true`) and **restart** homebridge.