### PR TITLE
Fix moonlight mode detection

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -128,9 +128,7 @@ class YeePlatform {
     const mixins = [];
     const limits = devices[model] || devices['default'];
 
-    // Lamps that support moonlight mode
-    if (features.includes('active_mode')) {
-      this.log(`Device ${name} supports moonlight mode`);
+    if (!hidden.includes('active_mode')) {
       mixins.push(MoonlightMode);
     }
 


### PR DESCRIPTION
As reported in #118 there is no value in the `support` array or attribute in the initial advertisement that allows for dynamically detecting if a device supports moonlight mode.

To work around this limitation we try to proactively send a `get_prop` request for `active_mode` and will initialize the moonlight feature accordingly.

Fixes #118.