### PR TITLE
Prepare for Homebridge v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": ">=16.16.0",
-    "homebridge": ">=1.3.0"
+    "homebridge": ">=1.3.0 || ^2.0.0-beta.0"
   },
   "scripts": {
     "prepare": "husky install",

--- a/platform.js
+++ b/platform.js
@@ -87,7 +87,7 @@ class YeePlatform {
 
   buildDevice(endpoint, { id, model, support, ...props }) {
     const deviceId = getDeviceId(id);
-    const name = getName(`${model}-${deviceId}`, this.config);
+    const name = getName(`${model} ${deviceId}`, this.config);
     const hidden = blacklist(deviceId, this.config);
     let accessory = this.devices[id];
 


### PR DESCRIPTION
- Add homebridge 2 to supported engines after doing some tests that did not reveal any issues.
- Remove `-` from generated device names as HAP is now validating that names contain only alpha numeric characters, apostrophes and spaces.